### PR TITLE
use path join to build the licenseDirectory path

### DIFF
--- a/lib/src/spdx/sbom_spdx_constants.dart
+++ b/lib/src/spdx/sbom_spdx_constants.dart
@@ -66,7 +66,8 @@ class SbomSpdxConstants {
   static const String licenseStandardHeader = 'standardLicenseHeader';
   static const String licenseSeeAlso = 'seeAlso';
   static const String licenseIsOsiApproved = 'isOsiApproved';
-  static const String licenceDirectory = 'lib/src/spdx/licences';
+  static final String licenceDirectory =
+      path.join('lib', 'src', 'spdx', 'licences');
 
   /// Tag value Validation
   static const List<String> packageTextTags = [


### PR DESCRIPTION
There is an issue running the code on Windows machines because the folder separator on Windows is '/' and on Mac is '\.'
A best practice is to use path.join() in stead of hardcoding the path. 